### PR TITLE
Add option to show device code to user directly

### DIFF
--- a/debian/pam_aad.conf
+++ b/debian/pam_aad.conf
@@ -7,6 +7,7 @@
     "id": "{{group_id}}"
   },
   "smtp_server": "{{smtp_server}}",
+  "email": "true",
   "tenant": {
     "name": "{{organization}}.onmicrosoft.com",
     "address": "{{organization_email_address}}"


### PR DESCRIPTION
Similar to #59, but uses `pam_prompt` to display output rather than `printf` (so that it is displayed over SSH) and moves the setting behind a configuration option.