### PR TITLE
Always allow access if group_id is an empty string

### DIFF
--- a/pam_aad.c
+++ b/pam_aad.c
@@ -479,7 +479,7 @@ STATIC int azure_authenticator(const char *user)
     jwt_decode(&jwt, ab_token, NULL, 0);
 
     if (verify_user(jwt, user_addr) == 0
-        && verify_group(ab_token, group_id, debug) == 0) {
+        && (strcmp(group_id,"")==0 || verify_group(ab_token, group_id, debug) == 0)) {
         ret = EXIT_SUCCESS;
     }
 


### PR DESCRIPTION
This change makes it so that the group membership check is skipped if `group_id` is empty.

The reasoning is that if our azure app is not authorised to read group membership with `/checkMemberGroups`, then this is a way to make `pam_aad` not worry about it, rather than error. (And group based access can be enforced with other PAM modules, if required.)